### PR TITLE
fix: address latest norminette v3.3.55 update incompatibility issue

### DIFF
--- a/.github/workflows/miniRT_test.yml
+++ b/.github/workflows/miniRT_test.yml
@@ -26,11 +26,11 @@ jobs:
       - uses: actions/checkout@v3
 
       # Runs a set of commands using the runners shell
-      - name: Set up Criterion framework on Ubuntu 22.04
+      - name: Set up Criterion framework and norminette on Ubuntu 22.04
         run: |
           sudo apt-get install libcriterion-dev libbsd-dev -y
           python3 -m pip install --upgrade pip setuptools
-          python3 -m pip install norminette
+          python3 -m pip install norminette==3.3.55
       # Runs a single command using the runners shell
       - name: Run norminette validation
         run: norminette include src

--- a/include/parser.h
+++ b/include/parser.h
@@ -6,12 +6,13 @@
 /*   By: yde-goes <yde-goes@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/05/10 12:11:15 by mdias-ma          #+#    #+#             */
-/*   Updated: 2023/06/16 13:40:10 by yde-goes         ###   ########.fr       */
+/*   Updated: 2024/04/04 09:50:05 by yde-goes         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 /// @file parser.h
 #ifndef PARSER_H
+# define PARSER_H
 
 # include <fcntl.h>
 # include <stdlib.h>
@@ -53,6 +54,29 @@ typedef enum e_token
 	TOKEN_ERROR,
 	TOKEN_COUNT
 }	t_token;
+
+/**
+ * @brief Stores the parameters of the shapes cone and cylinder from configuration
+ * file after they have been verified by the scanner. 
+ *
+ * @param origin Stores the origin of the cone or cylinder.
+ * @param direction Stores the direction of the cone or cylinder.
+ * @param diameter Stores the diameter of the cone or cylinder.
+ * @param height Stores the height of the cone or cylinder.
+ * @param radius Stores the radius of the cone or cylinder.
+ * @param minimum Stores the cone or cylinder minimum height, i.e, lowest height.
+ * @param maximum Stores the cone or cylinder maxinum height, i.e, highest height.
+ */
+typedef struct s_param
+{
+	t_point		origin;
+	t_vector	direction;
+	double		diameter;
+	double		height;
+	float		radius;
+	float		minimum;
+	float		maximum;
+}	t_param;
 
 /**
  * @brief Represents a scanner.

--- a/include/parser.h
+++ b/include/parser.h
@@ -6,7 +6,7 @@
 /*   By: yde-goes <yde-goes@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/05/10 12:11:15 by mdias-ma          #+#    #+#             */
-/*   Updated: 2024/04/04 09:50:05 by yde-goes         ###   ########.fr       */
+/*   Updated: 2024/04/04 13:28:12 by yde-goes         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -56,16 +56,16 @@ typedef enum e_token
 }	t_token;
 
 /**
- * @brief Stores the parameters of the shapes cone and cylinder from configuration
- * file after they have been verified by the scanner. 
+ * @brief Stores the parameters of the shapes cone and cylinder from
+ * configuration file after they have been verified by the scanner. 
  *
  * @param origin Stores the origin of the cone or cylinder.
  * @param direction Stores the direction of the cone or cylinder.
  * @param diameter Stores the diameter of the cone or cylinder.
  * @param height Stores the height of the cone or cylinder.
  * @param radius Stores the radius of the cone or cylinder.
- * @param minimum Stores the cone or cylinder minimum height, i.e, lowest height.
- * @param maximum Stores the cone or cylinder maxinum height, i.e, highest height.
+ * @param minimum Stores the cone or cylinder minimum height/lowest height.
+ * @param maximum Stores the cone or cylinder maxinum height/highest height.
  */
 typedef struct s_param
 {

--- a/include/shapes.h
+++ b/include/shapes.h
@@ -6,7 +6,7 @@
 /*   By: yde-goes <yde-goes@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/03/28 18:05:41 by mdias-ma          #+#    #+#             */
-/*   Updated: 2023/06/16 13:40:21 by yde-goes         ###   ########.fr       */
+/*   Updated: 2024/04/04 09:30:35 by yde-goes         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -105,7 +105,8 @@ typedef t_tuple				(*t_normal_at)(t_shape *, t_tuple);
  */
 typedef struct s_shape
 {
-	union {
+	union
+	{
 		t_sphere	sphere;
 		t_plane		plane;
 		t_cylinder	cylinder;

--- a/src/parser/parse_shapes_2.c
+++ b/src/parser/parse_shapes_2.c
@@ -3,25 +3,14 @@
 /*                                                        :::      ::::::::   */
 /*   parse_shapes_2.c                                   :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: mdias-ma <mdias-ma@student.42sp.org.br>    +#+  +:+       +#+        */
+/*   By: yde-goes <yde-goes@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/05/30 15:27:09 by mdias-ma          #+#    #+#             */
-/*   Updated: 2023/06/11 10:27:33 by mdias-ma         ###   ########.fr       */
+/*   Updated: 2024/04/04 09:33:36 by yde-goes         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "parser.h"
-
-typedef struct s_param
-{
-	t_point		origin;
-	t_vector	direction;
-	double		diameter;
-	double		height;
-	float		radius;
-	float		minimum;
-	float		maximum;
-}	t_param;
 
 static void	set_cone_attributes(t_shape *shape, t_param param);
 static void	set_cylinder_attributes(t_shape *shape, t_param param);


### PR DESCRIPTION
The latest norminette v3.3.55 doesn't allow students to choose between the K&R or Allman indentation style; instead, it enforces the use of the latter. The K&R indentation style is used in the original Unix kernel, while the Allman style is used in BSD Unix.

Deciding whether to pin the tools used on CD/CI or to keep them updated is a complex question. We must consider factors such as stability versus being up-to-date, security, long-term maintenance, and compatibility. Since the project is finished, it doesn't require long-term maintenance, nor will it have major security issues since the tool used is only a code formatter. Few changes had to be made, so I decided to update the code formatting to adhere to norminette 3.3.55 and pin it on our CI/CD workflow.

To sum up, this PR ensures that our CI/CD doesn't break due to external changes if we further tinker with this beautiful project.